### PR TITLE
Update supported versions statement on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 
 <p><strong>A:</strong> It is called simply "The X-Files" by SpideRaY, and is available to download <a href="http://www.dafont.com/the-x-files.font">here</a>.</p>
 
-<p>Also please note that Agent Mulder plugin requires ReSharper 6.1 and only works in Visual Studio 2010. Other versions were not tested!</p>
+<p>Also please note that Agent Mulder plugin requires ReSharper 6.1 or ReSharper 7 and works in both Visual Studio 2010 and Visual Studio 2012. Other versions were not tested!</p>
 
 <p>Happy Investigating!</p>
       </section>


### PR DESCRIPTION
The text at the bottom of the page states only ReSharper 6.1 and Visual Studio 2010 are supported.  However, ReSharper 7 and VS2012 are not supported.

I've altered the text to reflect this.
