### PR TITLE
Tests working for 9.1

### DIFF
--- a/src/AgentMulder.Containers.Autofac/AgentMulder.Containers.Autofac.8.2.csproj
+++ b/src/AgentMulder.Containers.Autofac/AgentMulder.Containers.Autofac.8.2.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.Autofac</RootNamespace>
     <AssemblyName>AgentMulder.Containers.Autofac</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.Autofac/AgentMulder.Containers.Autofac.9.0.csproj
+++ b/src/AgentMulder.Containers.Autofac/AgentMulder.Containers.Autofac.9.0.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.Autofac</RootNamespace>
     <AssemblyName>AgentMulder.Containers.Autofac</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.Autofac/app.config
+++ b/src/AgentMulder.Containers.Autofac/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.Containers.CastleWindsor/AgentMulder.Containers.CastleWindsor.8.2.csproj
+++ b/src/AgentMulder.Containers.CastleWindsor/AgentMulder.Containers.CastleWindsor.8.2.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.CastleWindsor</RootNamespace>
     <AssemblyName>AgentMulder.Containers.CastleWindsor</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.CastleWindsor/AgentMulder.Containers.CastleWindsor.9.0.csproj
+++ b/src/AgentMulder.Containers.CastleWindsor/AgentMulder.Containers.CastleWindsor.9.0.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.CastleWindsor</RootNamespace>
     <AssemblyName>AgentMulder.Containers.CastleWindsor</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.CastleWindsor/app.config
+++ b/src/AgentMulder.Containers.CastleWindsor/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.Containers.Catel/AgentMulder.Containers.Catel.8.2.csproj
+++ b/src/AgentMulder.Containers.Catel/AgentMulder.Containers.Catel.8.2.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.Catel</RootNamespace>
     <AssemblyName>AgentMulder.Containers.Catel</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.Catel/AgentMulder.Containers.Catel.9.0.csproj
+++ b/src/AgentMulder.Containers.Catel/AgentMulder.Containers.Catel.9.0.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.Catel</RootNamespace>
     <AssemblyName>AgentMulder.Containers.Catel</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.Catel/app.config
+++ b/src/AgentMulder.Containers.Catel/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.Containers.Ninject/AgentMulder.Containers.Ninject.8.2.csproj
+++ b/src/AgentMulder.Containers.Ninject/AgentMulder.Containers.Ninject.8.2.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.Ninject</RootNamespace>
     <AssemblyName>AgentMulder.Containers.Ninject</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.Ninject/AgentMulder.Containers.Ninject.9.0.csproj
+++ b/src/AgentMulder.Containers.Ninject/AgentMulder.Containers.Ninject.9.0.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.Ninject</RootNamespace>
     <AssemblyName>AgentMulder.Containers.Ninject</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.Ninject/app.config
+++ b/src/AgentMulder.Containers.Ninject/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.Containers.SimpleInjector/AgentMulder.Containers.SimpleInjector.8.2.csproj
+++ b/src/AgentMulder.Containers.SimpleInjector/AgentMulder.Containers.SimpleInjector.8.2.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.SimpleInjector</RootNamespace>
     <AssemblyName>AgentMulder.Containers.SimpleInjector</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.SimpleInjector/AgentMulder.Containers.SimpleInjector.9.0.csproj
+++ b/src/AgentMulder.Containers.SimpleInjector/AgentMulder.Containers.SimpleInjector.9.0.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.SimpleInjector</RootNamespace>
     <AssemblyName>AgentMulder.Containers.SimpleInjector</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.SimpleInjector/app.config
+++ b/src/AgentMulder.Containers.SimpleInjector/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.Containers.StructureMap/AgentMulder.Containers.StructureMap.8.2.csproj
+++ b/src/AgentMulder.Containers.StructureMap/AgentMulder.Containers.StructureMap.8.2.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.StructureMap</RootNamespace>
     <AssemblyName>AgentMulder.Containers.StructureMap</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.StructureMap/AgentMulder.Containers.StructureMap.9.0.csproj
+++ b/src/AgentMulder.Containers.StructureMap/AgentMulder.Containers.StructureMap.9.0.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.StructureMap</RootNamespace>
     <AssemblyName>AgentMulder.Containers.StructureMap</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.StructureMap/app.config
+++ b/src/AgentMulder.Containers.StructureMap/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.Containers.Unity/AgentMulder.Containers.Unity.8.2.csproj
+++ b/src/AgentMulder.Containers.Unity/AgentMulder.Containers.Unity.8.2.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.Unity</RootNamespace>
     <AssemblyName>AgentMulder.Containers.Unity</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.Unity/AgentMulder.Containers.Unity.9.0.csproj
+++ b/src/AgentMulder.Containers.Unity/AgentMulder.Containers.Unity.9.0.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.Containers.Unity</RootNamespace>
     <AssemblyName>AgentMulder.Containers.Unity</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\Containers\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.Containers.Unity/app.config
+++ b/src/AgentMulder.Containers.Unity/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.ReSharper.Domain/AgentMulder.ReSharper.Domain.8.2.csproj
+++ b/src/AgentMulder.ReSharper.Domain/AgentMulder.ReSharper.Domain.8.2.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.ReSharper.Domain</RootNamespace>
     <AssemblyName>AgentMulder.ReSharper.Domain</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.ReSharper.Domain/AgentMulder.ReSharper.Domain.9.0.csproj
+++ b/src/AgentMulder.ReSharper.Domain/AgentMulder.ReSharper.Domain.9.0.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.ReSharper.Domain</RootNamespace>
     <AssemblyName>AgentMulder.ReSharper.Domain</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.ReSharper.Domain/app.config
+++ b/src/AgentMulder.ReSharper.Domain/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.ReSharper.Plugin/AgentMulder.ReSharper.Plugin.8.2.csproj
+++ b/src/AgentMulder.ReSharper.Plugin/AgentMulder.ReSharper.Plugin.8.2.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.ReSharper.Plugin</RootNamespace>
     <AssemblyName>AgentMulder.ReSharper.Plugin</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.ReSharper.Plugin/AgentMulder.ReSharper.Plugin.9.0.csproj
+++ b/src/AgentMulder.ReSharper.Plugin/AgentMulder.ReSharper.Plugin.9.0.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.ReSharper.Plugin</RootNamespace>
     <AssemblyName>AgentMulder.ReSharper.Plugin</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>..\..\output\$(Configuration)\$(ReSharperSdkVersion)\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.ReSharper.Plugin/app.config
+++ b/src/AgentMulder.ReSharper.Plugin/app.config
@@ -32,4 +32,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.8.2.csproj
+++ b/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.8.2.csproj
@@ -106,6 +106,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Net46CompatibleFrameworkLocationHelper.cs" />
     <Compile Include="TestEnvironmentAssembly.8.2.cs" />
   </ItemGroup>
   <Import Project="..\shared\AgentMulder.ReSharper.Tests\AgentMulder.ReSharper.Tests.projitems" Label="Shared" Condition="Exists('..\shared\AgentMulder.ReSharper.Tests\AgentMulder.ReSharper.Tests.projitems')" />

--- a/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.8.2.csproj
+++ b/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.8.2.csproj
@@ -17,7 +17,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.ReSharper.Tests</RootNamespace>
     <AssemblyName>AgentMulder.ReSharper.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>bin\$(Configuration)\$(ReSharperSdkVersion)\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.9.0.csproj
+++ b/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.9.0.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <ReSharperSdkVersion>9.0</ReSharperSdkVersion>
     <ReSharperSdkMode>Tests</ReSharperSdkMode>
+    <JetTestProject>True</JetTestProject>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>b4e6420d</NuGetPackageImportStamp>
   </PropertyGroup>
@@ -78,14 +79,6 @@
     </Reference>
     <Reference Include="Microsoft.Deployment.Compression.Cab">
       <HintPath>..\packages\JetBrains.Platform.Lib.Microsoft.Deployment.Compression.Cab.2.0.20140304.0\lib\Microsoft.Deployment.Compression.Cab.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Unity.3.0.1304.1\lib\Net45\Microsoft.Practices.Unity.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Unity.3.0.1304.1\lib\Net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
@@ -198,6 +191,9 @@
       <Project>{b32f33e1-e0b4-4e8a-9aa5-70a3b2cedddd}</Project>
       <Name>AgentMulder.ReSharper.Plugin.9.0</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TestEnvironmentAssembly.9.0.cs" />
   </ItemGroup>
   <Import Project="..\shared\AgentMulder.ReSharper.Tests\AgentMulder.ReSharper.Tests.projitems" Label="Shared" Condition="Exists('..\shared\AgentMulder.ReSharper.Tests\AgentMulder.ReSharper.Tests.projitems')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.9.0.csproj
+++ b/src/AgentMulder.ReSharper.Tests/AgentMulder.ReSharper.Tests.9.0.csproj
@@ -17,7 +17,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AgentMulder.ReSharper.Tests</RootNamespace>
     <AssemblyName>AgentMulder.ReSharper.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OutputPath>bin\$(Configuration)\$(ReSharperSdkVersion)\</OutputPath>
     <BaseIntermediateOutputPath>obj\$(ReSharperSdkVersion)</BaseIntermediateOutputPath>

--- a/src/AgentMulder.ReSharper.Tests/Net46CompatibleFrameworkLocationHelper.cs
+++ b/src/AgentMulder.ReSharper.Tests/Net46CompatibleFrameworkLocationHelper.cs
@@ -1,0 +1,132 @@
+using System;
+using JetBrains.Application;
+using JetBrains.DataFlow;
+using JetBrains.ProjectModel.impl;
+using JetBrains.ProjectModel.Test.Components;
+using JetBrains.Util;
+
+namespace AgentMulder.ReSharper.Tests
+{
+    // We need to override TestSwitchingFrameworkLocationHelper, which is itself defined in the
+    // test assemblies and overrides SwitchingFrameworkLocationHelper (to allow finding frameworks
+    // in test data, rather than on the system). SwitchingFrameworkLocationHelper is the component
+    // in the main product, that by default returns *System*FrameworkLocationHelper (which isn't a
+    // component). But SystemFrameworkLocationHelper doesn't know about .net 4.6. So, we override
+    // the switcher, and every time it tries to use SystemFrameworkLocationHelper, we substitute in
+    // one that knows about .net 4.6. Easy, huh?
+    [ShellComponent]
+    public class Net46CompatibleFrameworkLocationHelper : TestSwitchingFrameworkLocationHelper
+    {
+        protected override IFrameworkDetectionHelper GetDefaultHelper()
+        {
+            var helper = base.GetDefaultHelper();
+            if (helper is SystemFrameworkLocationHelper)
+                return new SystemFrameworkLocationHelperFor46();
+            return helper;
+        }
+
+        private class SystemFrameworkLocationHelperFor46 : SystemFrameworkLocationHelper, IFrameworkDetectionHelper
+        {
+            public override FileSystemPath GetNetFrameworkDirectory(Version version)
+            {
+                if (version.ToString(2) == "4.6")
+                {
+                    return GetPathToDotNetFrameworkV46();
+                }
+                return base.GetNetFrameworkDirectory(version);
+            }
+
+            public override FileSystemPath GetMsBuildDirectory(Version version)
+            {
+                if (version >= new Version(4, 6))
+                {
+                    if (!CheckForFrameworkInstallation("Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Install"))
+                        return null;
+                    if (!(FindRegistryValueUnderKey("Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Version") ?? "").StartsWith("4.6.", StringComparison.Ordinal))
+                        return null;
+                    return Lifetimes.Using(lifetime =>
+                    {
+                        var root = RegistryUtil.OpenSoftwareKey(lifetime);
+                        if (root == null)
+                            return null;
+                        var registryKey = root.OpenSubKey(lifetime, "Microsoft\\MSBuild\\ToolsVersions\\14.0");
+                        if (registryKey == null)
+                            return null;
+                        var fileSystemPath1 = FileSystemPath.TryParse(registryKey.GetValue("MSBuildToolsRoot") as string);
+                        if (!fileSystemPath1.ExistsDirectory)
+                            return null;
+                        var fileSystemPath2 = fileSystemPath1.Combine("14.0").Combine("Bin");
+                        if (!fileSystemPath2.ExistsDirectory)
+                            return null;
+                        return fileSystemPath2;
+                    }) ?? base.GetMsBuildDirectory(new Version(4, 5));
+
+                }
+                return base.GetMsBuildDirectory(version);
+            }
+
+            Version IFrameworkDetectionHelper.GetMsBuildVersion(Version platformVersion)
+            {
+                return platformVersion >= new Version(4, 6) ? new Version(14, 0) : base.GetMsBuildVersion(platformVersion);
+            }
+
+            private static FileSystemPath GetPathToDotNetFrameworkV46()
+            {
+                if (!CheckForFrameworkInstallation("Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Install")
+                    || !(FindRegistryValueUnderKey("Microsoft\\NET Framework Setup\\NDP\\v4\\Full", "Version") ?? "").StartsWith("4.6.", StringComparison.Ordinal))
+                {
+                    return null;
+                }
+                return FindDotNetFrameworkPath("v4.0", "mscorlib.dll");
+            }
+
+            private static bool CheckForFrameworkInstallation(string registryEntryToCheckInstall, string registryValueToCheckInstall)
+            {
+                return FindRegistryValueUnderKey(registryEntryToCheckInstall, registryValueToCheckInstall) == "1";
+            }
+
+            private static string FindRegistryValueUnderKey(string registryBaseKeyName, string registryKeyName)
+            {
+                return Lifetimes.Using(lifetime =>
+                {
+                    var registryKey1 = RegistryUtil.OpenSoftwareKey(lifetime);
+                    if (registryKey1 == null)
+                        return null;
+                    using (var registryKey2 = registryKey1.OpenSubKey(registryBaseKeyName))
+                    {
+                        if (registryKey2 == null)
+                            return null;
+                        var obj = registryKey2.GetValue(registryKeyName);
+                        return obj == null ? null : obj.ToString();
+                    }
+                });
+            }
+
+            private static FileSystemPath FindDotNetFrameworkPath(string prefix, string requiredFile = null)
+            {
+                return Lifetimes.Using(lifetime =>
+                {
+                    var root = RegistryUtil.OpenSoftwareKey(lifetime);
+                    if (root == null)
+                        return null;
+                    var registryKey = root.OpenSubKey(lifetime, "Microsoft\\.NETFramework");
+                    if (registryKey == null)
+                        return null;
+                    var path = FileSystemPath.TryParse(registryKey.GetValue("InstallRoot") as string);
+                    if (!path.ExistsDirectory)
+                        return null;
+                    foreach (var fileSystemPath in path.GetChildDirectories())
+                    {
+                        if (fileSystemPath.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                            && (string.IsNullOrEmpty(requiredFile)
+                                || fileSystemPath.Combine(requiredFile).ExistsFile))
+                        {
+                            return fileSystemPath;
+                        }
+                    }
+                    return null;
+                });
+            }
+        }
+    }
+}

--- a/src/AgentMulder.ReSharper.Tests/TestEnvironmentAssembly.8.2.cs
+++ b/src/AgentMulder.ReSharper.Tests/TestEnvironmentAssembly.8.2.cs
@@ -1,9 +1,12 @@
+using System;
 using AgentMulder.ReSharper.Plugin.Components;
 using JetBrains.Application;
 using JetBrains.ReSharper;
 using JetBrains.Threading;
 using System.Reflection;
 using System.Collections.Generic;
+using AgentMulder.ReSharper.Tests;
+using JetBrains.Build.AllAssemblies;
 using NUnit.Framework;
 
 /// <summary>
@@ -17,10 +20,10 @@ public abstract class IsolatedReSharperTestEnvironmentAssembly : ReSharperTestEn
 {
     public override IApplicationDescriptor CreateApplicationDescriptor()
     {
-        return new IsolatedReSharperApplicationDescriptor();
+        return new CustomReSharperApplicationDescriptor();
     }
 
-    private class IsolatedReSharperApplicationDescriptor : ReSharperApplicationDescriptor
+    private class CustomReSharperApplicationDescriptor : ReSharperApplicationDescriptor
     {
         public override string ProductName
         {
@@ -32,8 +35,38 @@ public abstract class IsolatedReSharperTestEnvironmentAssembly : ReSharperTestEn
                 return base.ProductName + "_Isolated";
             }
         }
+
+        // ReSharper 8.2 doesn't know anything about .net 4.6, and throws exceptions.
+        // We can teach it by overriding the default FrameworkLocationHelper class, but
+        // it must be overridden before the ShellComponents are composed, and the call
+        // to AssemblyManager in SetUp is too late for that. So, we add this assembly
+        // into the list of product assemblies that are used by default when composing
+        // the Shell container. Hacky, but at least it lets us run the tests.
+        private AllAssembliesXml allAssembliesXml;
+
+        public override AllAssembliesXml AllAssembliesXml
+        {
+            get
+            {
+                if (allAssembliesXml != null)
+                    return allAssembliesXml;
+
+                allAssembliesXml = base.AllAssembliesXml;
+                var assemblies = new List<ProductAssemblyXml>(allAssembliesXml.Assemblies)
+                {
+                    new ProductAssemblyXml
+                    {
+                        Configurations = "Common",
+                        Name = typeof(Net46CompatibleFrameworkLocationHelper).Assembly.GetName().Name
+                    }
+                };
+                allAssembliesXml.Assemblies = assemblies.ToArray();
+                return allAssembliesXml;
+            }
+        }
     }
 }
+
 
 [SetUpFixture]
 public class TestEnvironmentAssembly : IsolatedReSharperTestEnvironmentAssembly
@@ -44,7 +77,8 @@ public class TestEnvironmentAssembly : IsolatedReSharperTestEnvironmentAssembly
   /// </summary>
   private static IEnumerable<Assembly> GetAssembliesToLoad()
   {
-    yield return Assembly.GetExecutingAssembly();
+    // Don't include this assembly, it's already been added as part of AllAssembliesXml above
+    yield return typeof(SolutionAnalyzer).Assembly;
   }
 
   public override void SetUp()

--- a/src/AgentMulder.ReSharper.Tests/TestEnvironmentAssembly.9.0.cs
+++ b/src/AgentMulder.ReSharper.Tests/TestEnvironmentAssembly.9.0.cs
@@ -1,19 +1,10 @@
-﻿﻿using System.Collections.Generic;
-using System.Reflection;
-﻿using AgentMulder.ReSharper.Plugin.Daemon;
-﻿using JetBrains.Annotations;
-using JetBrains.Application;
-﻿using JetBrains.Application.BuildScript.Solution;
+﻿﻿using JetBrains.Application.BuildScript.Application.Zones;
+﻿using JetBrains.ReSharper.TestFramework;
 ﻿using JetBrains.TestFramework;
-﻿using JetBrains.Threading;
-using NUnit.Framework;
- 
-using JetBrains.Application.BuildScript.Application.Zones;
-﻿using JetBrains.ReSharper.Resources.Shell;
-using JetBrains.ReSharper.TestFramework;
-using JetBrains.TestFramework.Application.Zones;
+﻿using JetBrains.TestFramework.Application.Zones;
+﻿using NUnit.Framework;
 
-[assembly: TestDataPathBase(@"..\Test\Data")]
+[assembly: TestDataPathBase(@"Test\Data")]
 
 [ZoneDefinition]
 public class TestEnvironmentZone : ITestsZone, IRequire<PsiFeatureTestZone>
@@ -21,32 +12,6 @@ public class TestEnvironmentZone : ITestsZone, IRequire<PsiFeatureTestZone>
 }
 
 [SetUpFixture]
-public class ReSharperTestEnvironmentAssembly : TestEnvironmentAssembly<TestEnvironmentZone>
+public class ReSharperTestEnvironmentAssembly : ExtensionTestEnvironmentAssembly<TestEnvironmentZone>
 {
-    [NotNull]
-    private static IEnumerable<Assembly> GetAssembliesToLoad()
-    {
-        yield return Assembly.GetExecutingAssembly();
-    }
-
-    public override void SetUp()
-    {
-        base.SetUp();
-        ReentrancyGuard.Current.Execute("LoadAssemblies", () =>
-        {
-            var assemblyManager = Shell.Instance.GetComponent<AssemblyManager>();
-            assemblyManager.LoadAssemblies(GetType().Name, GetAssembliesToLoad());
-        });
-    }
-
-    public override void TearDown()
-    {
-        ReentrancyGuard.Current.Execute("UnloadAssemblies", () =>
-        {
-            var assemblyManager = Shell.Instance.GetComponent<AssemblyManager>();
-            assemblyManager.UnloadAssemblies(GetType().Name, GetAssembliesToLoad());
-        });
-
-        base.TearDown();
-    }
 }

--- a/src/Shared/AgentMulder.ReSharper.Tests/Autofac/ContainerBuilderTests.cs
+++ b/src/Shared/AgentMulder.ReSharper.Tests/Autofac/ContainerBuilderTests.cs
@@ -2,7 +2,7 @@ using AgentMulder.Containers.Autofac;
 
 namespace AgentMulder.ReSharper.Tests.Autofac
 {
-    [TestWithNuGetPackage(Packages = new[] { "Autofac" })]
+    [TestWithNuGetPackage(Packages = new[] { "Autofac:3.5.2" })]
     public class ContainerBuilderTests : AgentMulderTestBase<AutofacContainerInfo>
     {
         protected override string RelativeTestDataPath

--- a/src/Test/Data/NuGet.config
+++ b/src/Test/Data/NuGet.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+  </config>
+  <packageSources>
+    <clear />
+    <add key="jb-gallery" value="http://jb-gallery.azurewebsites.net/api/v2/curated-feeds/TestNuggets/" />
+    <add key="nuget.org" value="http://www.nuget.org/api/v2/" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+  <packageRestore>
+    <!-- Allow NuGet to download missing packages -->
+    <add key="enabled" value="True" />
+
+    <!-- Automatically check for missing packages during build in Visual Studio -->
+    <add key="automatic" value="False" />
+  </packageRestore>
+</configuration>


### PR DESCRIPTION
Here are the changes. PLEASE READ THIS! :smile: 

- [x] Added `JetTestProject=True` to test project to indicate that it is a test project and make sure all assemblies and other content are correctly copied. This is likely to be handled by the `JetBrains.ReSharper.SDK.Tests` package for 9.1 RTM (this package wasn't used in 9.0)
- [x] `ReSharperTestEnvironmentAssembly` for 9.1 now derives from `ExtensionTestEnvironmentAssembly<T>` and has no implementation (all assemblies come from the bin folder, no need to specify)
- [x] `AgentMulderTestBase.TestCases` for 9.1 infers the product root and sets the `%JetProductHomeDir%` environment variable. Without this, the base test class tries to set up the environment based on building the product, not an extension, and throws an exception. The `ExtensionTestEnvironmentAssembly` handles this under normal circumstances (it infers the location and sets the environment variable), but `TestCases` is called before the environment fixture is invoked, so it doesn't get a chance to. So we must do it here, manually too. This should be fixed in a future update to the SDK ([RSRP-437038](https://youtrack.jetbrains.com/issue/RSRP-437038))
- [x] Fixed up `[TestDataPath]` attribute to point to the correct location - it's a path relative to product root, not executing assembly. This is currently required, even though it's marked as obsolete. It might be possible to remove once 9.1 hits RTM, but the `TestCases` issue above might still require it.
- [x] Added a `nuget.config` file to allow downloading system frameworks from JetBrains repo. This allows testing against other .net frameworks than what you've got installed on the local machine, but does take up a lot of space. The packages are LARGE, and downloaded to `%TEMP%\JetTestPackages`, and will be re-downloaded (or pulled from the nuget cache) if the folder is deleted. Other nuget packages used by the tests (e.g. Autofac, etc.) are also downloaded to this location.
- [x] All assemblies have been put back to .net 4.0, to work with greater compatibility, but also to work around issue with arithmetic overflow exception when running tests in .net 4.5 ([RSRP-414105](https://youtrack.jetbrains.com/issue/RSRP-414105))
- [x] 8.2 tests can work on a machine with .net 4.6 installed

Unimplemented changes, left as an exercise for the repo owner:

- [ ] Fix the failing tests! Even 8.2 has some failing tests...
- [ ] 9.1 tests need to specify version of nuget packages for remaining tests (they throw exceptions otherwise)
- [ ] NuGet.config could add local packages folder as a source to prevent need to re-download package (although it's likely to come from NuGet's cache anyway)
- [ ] It is possible to prevent ReSharper downloading system frameworks (because they're REALLY big - e.g. 1gig), by applying a custom `ITestPackagesProvider` implementation (e.g. `TestPackagesAttribute`) as an attribute to the test class, that returns an empty list for `GetPackages` and returns `true` to `Inherit` so that the `BaseTestWithSolution`'s default `[TestNetFramework35]` isn't picked up